### PR TITLE
[fix & add] _ [clean code화 진행(2) _ 가독성 & 기능적 측면]

### DIFF
--- a/collision_enemy_check.c
+++ b/collision_enemy_check.c
@@ -1,0 +1,27 @@
+/*
+init_enemies가 필요시에만 작동할수 있도록 하는 과정에서 포인터 매개변수가 추가되었습니다.
+해당 변수가 1일 때에는 게임의 판이 진행중임을 의미하며 0일때에는 게임의 판이 종료된 것을 의미합니다.
+해당 함수에서는 진행상태에서 종료상태로 변화할때를 구현하게 되었습니다. 
+*/
+void collision_enemy_check(Game* g, int i, int j, int* flag)
+{
+    int k;
+    k = has_enemy_in_pos(g, i, j);
+    if(k >= 0)
+    {
+        g->coins[k].i = -99;
+        g->coins[k].j = -99;
+        g->lifes--;
+
+        //부딪힌 경우에는 팩맨을 다시 맵 정중앙으로 위치 시킨다.
+        g->pacman.y_axis = CELL_SIZE/2;
+        g->pacman.x_axis = CELL_SIZE/2;
+
+        //부딪힌 경우에는 멈춤 상태로 다시 변한다.
+        g->pacman.direction = PAUSE;
+        g->enemies_movement = PAUSE;
+
+        //진행상태에서 종료상태로 바꾸기 위한 포인터변수값 초기화.
+        *flag = 0;
+    }
+}

--- a/main2.c
+++ b/main2.c
@@ -1,0 +1,63 @@
+/*
+init_enemies함수가 반복호출되는 것을 막기위한 조치를 취했습니다.
+flag 변수가 0인 경우에는 게임이 시작되지 않은 상태를 나타내고,
+flag 변수가 1인 경우에는 게임이 시작된 상태를 나타냅니다.
+그렇기에 0->1로 바뀌는 경우에만 init_enemies가 호출되게 됩니다.
+
+사전에 말씀드린 대로 1->0으로 바뀐 부분(진행 상태에서 종료상태로의 진행)을 위해서,
+효재님이 맡으신 collision_enemy_check의 매개변수에 포인터 변수[flag]를 하나 추가했습니다.
+이외에는 전부 동일한 내용입니다.
+*/
+
+int main()
+{
+    Game j;
+    int jogando = 1;
+    char c = 'v';
+    int flag = 0;
+
+    init_game(&j);
+
+    while(jogando)
+    {
+        //딜레이 시간 설정.
+        delay(150);
+        clrscr();
+        if(kbhit())
+        {
+            //버퍼값 입력.
+            c = getch();
+
+            //init_enemies가 필요시에만 호출되기 위한 장치.
+            if(c != 'v' && flag == 0){
+              init_enemies(&j);
+              flag = 1;
+            }
+            change_direction(&j, c);
+        }
+
+        //팩맨 움직임.
+
+        move_pacman(&j);
+        //형평성을 위해서 팩맨은 1.5초간 연속으로 움직여도 되는가?
+        //적은 딱 한번만 움직이는데...
+
+        //움직임 후 상태 확인
+        collision_coin_check(&j, j.pacman.y_axis, j.pacman.x_axis);
+        //진행상태에서 종료상태로 바꾸기위해 매개변수가 하나더 추가된 collision_enemy_check.
+        collision_enemy_check(&j, j.pacman.y_axis, j.pacman.x_axis, &flag);
+
+        //움직임 후 상태 변화
+        draw_scene(&j);
+        move_enemies(&j);
+        printf("Score: %d\nLifes: %d\n", j.score, j.lifes);
+
+        //종료 조건.
+        if(j.total_coin_number == 0 || j.lifes == 0) jogando = 0;
+
+    }
+
+    printf("Game over.");
+
+    return 0;
+}


### PR DESCRIPTION
init_enemies를 필요시에만 호출되도록 수정하였습니다.
해당 수정을 진행하기 위해서는 main, collision_enemy_check 두가지를 수정헀습니다.

 메인 함수에서 init_enemies가 계속 입력이 되고 있습니다. 게임을 시작하는 경우에만
호출하면 되는데, 매번 호출되는 것은 기능적 & 가독성에도 안 좋다고 판단합니다.
우선 팩맨이 정지상태에서 바뀌는 경우에만 init_enemies를 호출할 계획입니다.
 변수(flag)를 선언해서 게임 중일때에는 1인 상태를 유지하는 반면 게임이 끝난 경우는 0을 의미하게 설정합니다.
change_direction에서 방향키 입력값이 null이 아니고 flag가 0일 때, flag의 상태를 1로 바꾸어서 적의 상태를 바꾸는 함수를 한번만 호출하게 합니다.
그리고 팩맨과 적이 충돌할 경우에는 falg를 collistion_enemy_check에서 0으로 바꿉니다.